### PR TITLE
Move nested frame into iframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,11 @@ For testing popup & iframe related features.
 #### `/frame.html`
 
 Displayed as `iframe#cool-frame` and contains `div.in-iframe-only`
-and `frame#nested-frame`. The nested frame contains `div#nested-frame-div`.
+and `iframe#nested-frame` (see `/nested-frame.html`).
+
+#### `/nested-frame.html`
+
+This page contains `div#nested-frame-div`.
 
 #### `/popup.html`
 

--- a/public/frame.html
+++ b/public/frame.html
@@ -12,9 +12,7 @@
       iframe content!
     </div>
 
-    <frame id="nested-frame">
-      <div id="nested-frame-div"></div>
-    </frame>
+    <iframe id="nested-frame" src="nested-frame.html"></iframe>
 
   </body>
 </html>

--- a/public/nested-frame.html
+++ b/public/nested-frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Some Nested IFrame</title>
+    <style>
+      body { background-color: white; }
+    </style>
+  </head>
+  <body>
+    <div id="nested-frame-div">Nested frame div</div>
+  </body>
+</html>


### PR DESCRIPTION
This is a major change. The problem with the previous layout was that it doesn't actually other bother selenium when content is in a `<frame>`. And switching to a `<frame>` isn't a thing - it will just fail.

See: https://github.com/testiumjs/testium-driver-sync/pull/6
