### PR TITLE
chore: Ship public and server to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "files": [
     "*.js",
-    "lib"
+    "public"
   ],
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
This got broken when switching to nlm.
